### PR TITLE
Use newer kernel version when there are multiple available

### DIFF
--- a/training/intel-bootc/Containerfile
+++ b/training/intel-bootc/Containerfile
@@ -15,8 +15,9 @@ RUN if [ "${OS_VERSION_MAJOR}" == "" ]; then \
        export TARGET_ARCH=$(arch) ;\
        fi \
     && if [ "${KERNEL_VERSION}" == "" ]; then \
-       RELEASE=$(dnf info --installed kernel-core | grep Release | awk -F: '{print $2}' | tr -d '[:blank:]') \
-       && VERSION=$(dnf info --installed kernel-core | grep Version | awk -F: '{print $2}' | tr -d '[:blank:]') \
+        NEWER_KERNEL_CORE=$(dnf info kernel-core | awk -F: '/^Source/{gsub(/.src.rpm/, "", $2); print $2}' | sort -n | tail -n1) \
+        && RELEASE=$(dnf info ${NEWER_KERNEL_CORE} | awk -F: '/^Release/{print $2}' | tr -d '[:blank:]') \
+        && VERSION=$(dnf info ${NEWER_KERNEL_CORE} | awk -F: '/^Version/{print $2}' | tr -d '[:blank:]') \
        && export KERNEL_VERSION="${VERSION}-${RELEASE}" ;\
        fi \
     && dnf install -y make git kernel-devel-${KERNEL_VERSION} \
@@ -62,9 +63,10 @@ ARG INSTRUCTLAB_IMAGE
 ARG VLLM_IMAGE
 
 RUN if [ "${KERNEL_VERSION}" == "" ]; then \
-        RELEASE=$(dnf info --installed kernel-core | grep Release | awk -F: '{print $2}' | tr -d '[:blank:]') \
-        && VERSION=$(dnf info --installed kernel-core | grep Version | awk -F: '{print $2}' | tr -d '[:blank:]') \
-        && export KERNEL_VERSION="${VERSION}-${RELEASE}" ;\
+       NEWER_KERNEL_CORE=$(dnf info kernel-core | awk -F: '/^Source/{gsub(/.src.rpm/, "", $2); print $2}' | sort -n | tail -n1) \
+       && RELEASE=$(dnf info ${NEWER_KERNEL_CORE} | awk -F: '/^Release/{print $2}' | tr -d '[:blank:]') \
+       && VERSION=$(dnf info ${NEWER_KERNEL_CORE} | awk -F: '/^Version/{print $2}' | tr -d '[:blank:]') \
+       && export KERNEL_VERSION="${VERSION}-${RELEASE}" ;\
     fi \
     && if [ "${TARGET_ARCH}" == "" ]; then \
        export TARGET_ARCH=$(arch) ;\

--- a/training/nvidia-bootc/Containerfile
+++ b/training/nvidia-bootc/Containerfile
@@ -22,8 +22,9 @@ COPY --chown=1001:0 x509-configuration.ini x509-configuration.ini
 COPY build/usr /usr
 
 RUN if [ "${KERNEL_VERSION}" == "" ]; then \
-        RELEASE=$(dnf info kernel-core | grep Release | awk -F: '{print $2}' | tr -d '[:blank:]') \
-        && VERSION=$(dnf info kernel-core | grep Version | awk -F: '{print $2}' | tr -d '[:blank:]') \
+        NEWER_KERNEL_CORE=$(dnf info kernel-core | awk -F: '/^Source/{gsub(/.src.rpm/, "", $2); print $2}' | sort -n | tail -n1) \
+        && RELEASE=$(dnf info ${NEWER_KERNEL_CORE} | awk -F: '/^Release/{print $2}' | tr -d '[:blank:]') \
+        && VERSION=$(dnf info ${NEWER_KERNEL_CORE} | awk -F: '/^Version/{print $2}' | tr -d '[:blank:]') \
         && export KERNEL_VERSION="${VERSION}-${RELEASE}" ;\
     fi \
     && if [ "${OS_VERSION_MAJOR}" == "" ]; then \

--- a/training/nvidia-bootc/Containerfile.builder
+++ b/training/nvidia-bootc/Containerfile.builder
@@ -6,8 +6,9 @@ ARG ENABLE_RT=''
 USER root
 
 RUN if [ "${KERNEL_VERSION}" == "" ]; then \
-        RELEASE=$(dnf info kernel-core | grep Release | awk -F: '{print $2}' | tr -d '[:blank:]') \
-        && VERSION=$(dnf info kernel-core | grep Version | awk -F: '{print $2}' | tr -d '[:blank:]') \
+        NEWER_KERNEL_CORE=$(dnf info kernel-core | awk -F: '/^Source/{gsub(/.src.rpm/, "", $2); print $2}' | sort -n | tail -n1) \
+        && RELEASE=$(dnf info ${NEWER_KERNEL_CORE} | awk -F: '/^Release/{print $2}' | tr -d '[:blank:]') \
+        && VERSION=$(dnf info ${NEWER_KERNEL_CORE} | awk -F: '/^Version/{print $2}' | tr -d '[:blank:]') \
         && export KERNEL_VERSION="${VERSION}-${RELEASE}" ;\
         fi \
     && echo "${KERNEL_VERSION}" \


### PR DESCRIPTION
Cherry-picks containers/ai-lab-recipes#488

Without this, `make nvidia` was failing for me because the kernel version detection code assumes `dnf info` will only return details of one kernel package, but currently it shows two - the one installed (`5.14.0-427.16.1.el9_4`), and a newer one available (`5.14.0-427.18.1.el9_4`)

```
$ make nvidia FROM=registry.redhat.io/rhel9/rhel-bootc:9.4 REGISTRY=quay.io REGISTRY_ORG=markmc
...
STEP 5/7: RUN if [ "${KERNEL_VERSION}" == "" ]; then         RELEASE=$(dnf info kernel-core | grep Release | awk -F: '{print $2}' | tr -d '[:blank:]')         && VERSION=$(dnf info kernel-core | grep Version 
| awk -F: '{print $2}' | tr -d '[:blank:]')         && export KERNEL_VERSION="${VERSION}-${RELEASE}" ;        fi     && echo "${KERNEL_VERSION}"     && dnf -y install dnf-plugin-config-manager     && dnf conf
ig-manager --best --nodocs --setopt=install_weak_deps=False --save     && dnf -y install         kernel-devel-${KERNEL_VERSION}         kernel-modules-${KERNEL_VERSION}         kernel-modules-extra-${KERNEL_V
ERSION}     && if [ "${ENABLE_RT}" ] && [ $(arch) == "x86_64" ]; then         dnf -y --enablerepo=rt install             kernel-rt-devel-${KERNEL_VERSION}             kernel-rt-modules-${KERNEL_VERSION}      
       kernel-rt-modules-extra-${KERNEL_VERSION};     fi     && export INSTALLED_KERNEL=$(rpm -q --qf "%{VERSION}-%{RELEASE}.%{ARCH}" kernel-core-${KERNEL_VERSION})     && export GCC_VERSION=$(cat /lib/module
s/${INSTALLED_KERNEL}/config | grep -Eo "gcc \(GCC\) ([0-9\.]+)" | grep -Eo "([0-9\.]+)")     && dnf -y install         binutils         diffutils         elfutils-libelf-devel         jq         kabi-dw kern
el-abi-stablelists         keyutils         kmod         gcc-${GCC_VERSION}         git         make         mokutil         openssl         pinentry         rpm-build         xz     && dnf clean all     && u
seradd -u 1001 -m -s /bin/bash builder
5.14.0
5.14.0-427.16.1.el9_4
427.18.1.el9_4
...
No match for argument: 5.14.0-427.16.1.el9_4
No match for argument: 427.18.1.el9_4
Package kernel-modules-5.14.0-427.16.1.el9_4.x86_64 is already installed.
Error: Unable to find a match: 5.14.0-427.16.1.el9_4 427.18.1.el9_4
```