### PR TITLE
README.md: define HF_TOKEN to download granite model

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,15 @@ steps, so it is recommended to do so.
 ilab init
 ```
 
+#### Set up your Hugging Face token
+
+Define an environment variable using the HF token you created in the above section under
+Access Tokens.
+
+```shell
+export HF_TOKEN=<paste token value here>
+````
+
 #### Download Granite-7B (~27GB on disk)
 
 Next, download the IBM Granite base model. Important: Do not download the “lab”
@@ -326,11 +335,9 @@ ilab download --repository ibm/granite-7b-base
 
 #### Download Mixtral-8x7B-Instruct (~96GB on disk)
 
-Follow the same process, but additionally define an environment variable using
-the HF token you created in the above section under Access Tokens.
+Follow the same process to download the Mixtral model.
 
 ```shell
-export HF_TOKEN=<paste token value here>
 ilab download --repository mistralai/Mixtral-8x7B-Instruct-v0.1
 ```
 


### PR DESCRIPTION
Without this, I got:

```
$ ilab download --repository ibm/granite-7b-base
Downloading model from ibm/granite-7b-base@main to models...
Traceback (most recent call last):
  File "/usr/local/bin/ilab", line 8, in <module>
    sys.exit(cli())
             ^^^^^
  File "/usr/local/lib/python3.11/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/click/decorators.py", line 33, in new_func
    return f(get_current_context(), *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/instructlab/lab.py", line 800, in download
    raise ValueError(
ValueError: HF_TOKEN var needs to be set in your environment to download HF Model. 
            Alternatively, the token can be passed with --hf-token flag. 
            The HF Token is used to authenticate your identity to the Hugging Face Hub.
```