### PR TITLE
Need Fix for CVE-2024-5480

### DIFF
--- a/training/deepspeed/Containerfile
+++ b/training/deepspeed/Containerfile
@@ -3,7 +3,7 @@ FROM nvcr.io/nvidia/cuda:12.1.1-cudnn8-devel-ubi9
 
 RUN dnf install -y python python-devel git
 RUN python -m ensurepip --upgrade
-RUN pip3 install torch==2.1.2 --index-url https://download.pytorch.org/whl/cu121
+RUN pip3 install torch==2.3.1 --index-url https://download.pytorch.org/whl/cu121
 RUN pip3 install packaging wheel
 RUN pip3 install flash-attn==2.5.7
 RUN pip3 install deepspeed==0.14.2


### PR DESCRIPTION
Need to fix [CVE-2024-5480](https://nvd.nist.gov/vuln/detail/CVE-2024-5480) as it's a critical issue in the PyTorch distributed RPC framework and can lead to remote code execution (RCE) while multi-cpu RPC communication. 

Although the vulnerable version of Pytorch is used or install via pip, but the vulnerable function is not called/used for RHEL-AI, that is 'torch.distributed.rpc' or any kind of rpc.

**_**Ref & PoC & More at** https://huntr.com/bounties/39811836-c5b3-4999-831e-46fee8fcade3_**

**Before marge please test all functionality and do required code changes to merge it in main branch.**

Thanks
Sandipan Roy