### PR TITLE
Add support for running ilab container in background or foreground mode

### DIFF
--- a/training/ilab-wrapper/ilab
+++ b/training/ilab-wrapper/ilab
@@ -102,8 +102,16 @@ get_model() {
 	fi
 }
 
+if [[ "${PODMAN_BACKGROUND_MODE}" == "true" ]]; then
+	echo "Running in background mode"
+	PODMAN_BACKGROUND_MODE_FLAGS="--detach"
+else
+	echo "Running in foreground mode"
+	PODMAN_BACKGROUND_MODE_FLAGS="--interactive"
+fi
+
 mkdir -p "${HOST_CACHE}"
-PODMAN_COMMAND=("podman" "run" "--rm" "-it" "--device" "${CONTAINER_DEVICE}" \
+PODMAN_COMMAND=("podman" "run" "--rm" "-t" "${PODMAN_BACKGROUND_MODE_FLAGS}" "--device" "${CONTAINER_DEVICE}" \
 		"--security-opt" "label=disable" "--net" "host" \
 		"-v" "${WORKDIR}:/instructlab" "--entrypoint" "" \
 		"-e" "HF_HOME=${CONTAINER_CACHE}" \


### PR DESCRIPTION
- Introduce PODMAN_BACKGROUND_MODE environment variable to control podman run mode
- Use --detach flag for background mode and --interactive flag for foreground mode
- Update PODMAN_COMMAND to include the appropriate flag based on PODMAN_BACKGROUND_MODE

This change allows the script to conditionally run ilab podman containers in the background or foreground based on the value of the PODMAN_BACKGROUND_MODE environment variable